### PR TITLE
Disable lockfile resolution in action.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,11 @@
 # currently built
 FROM qixtand/debian-buster-curl
 
+# The tidelift alignment action assumes lockfiles are already generated,
+# lockfiles, so we disable lockfile generation.
+ENV TIDELIFT_GO_NO_RESOLVE=1                                                                                                      
+ENV TIDELIFT_MAVEN_NO_RESOLVE=1                                                                                                      
+ENV TIDELIFT_GRADLE_NO_RESOLVE=1                                                                                                      
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The tools required for lockfile resolution don't exist in the Docker image by default and the action assumes lockfiles already exist, so disable any lockfile resolution while running the alignment.